### PR TITLE
Add SQLite (with WRITE support)

### DIFF
--- a/libsqlite/.gitignore
+++ b/libsqlite/.gitignore
@@ -1,0 +1,1 @@
+libsqlite

--- a/libsqlite/VITABUILD
+++ b/libsqlite/VITABUILD
@@ -1,0 +1,16 @@
+pkgname=libsqlite
+pkgver=9999
+pkgrel=1
+url="https://github.com/VitaSmith/libsqlite"
+source=("git://github.com/VitaSmith/libsqlite.git")
+sha256sums=('SKIP')
+
+build() {
+  cd $pkgname/$pkgname
+  make
+}
+
+package () {
+  cd $pkgname/$pkgname
+  make DESTDIR=$pkgdir install
+}

--- a/travis_packages.sh
+++ b/travis_packages.sh
@@ -20,6 +20,7 @@ b libogg
 b libvorbis
 b libtremor
 b libftpvita
+b libsqlite
 b henkaku
 b taihen
 b libk


### PR DESCRIPTION
The current SDK provides only support for the default SQLite implementation
from Sony, which is locked down to read-only and is therefore pretty limited.

This patch adds full R/W support, through a new libsqlite.a library, as well
as 2 new calls: sqlite3_rw_init() and sqlite3_rw_exit().

See https://github.com/VitaSmith/libsqlite for details and samples.

Additional Notes:
-------------------

* Note that `make install` of libsqlite is designed to __override__ the existing `include\psp2\sqlite.h` (to add the `sqlite3_rw_init()` and `sqlite3_rw_exit()` declaration, as I don't think it would make much sense to require SQLite Vita users to use 3 different headers (one for `sceSqliteConfigMallocMethods()`, one for the new `sqlite3_rw_###` and one last for the regular `sqlite3.h`). If this proposal is integrated, I can submit a patch against _vita-headers_ to make the `sqlite.h` modification permanent, in which case I'll modify `make install` to just copy the library.
* The way R/W support is achieved is by overriding the VFS, with just the minimal subset of what we need (`xOpen()`, `xDelete()` and `xWrite()`), while leaving as much as possible of the original VFS untouched.