### PR TITLE
update SDL2 by redirecting to maintained port by rsn8887 and Cpasjuste

### DIFF
--- a/sdl2/VITABUILD
+++ b/sdl2/VITABUILD
@@ -1,8 +1,8 @@
 pkgname=sdl2
 pkgver=9999
 pkgrel=1
-url="https://github.com/xerpi/SDL-Vita.git"
-source=("git://github.com/xerpi/SDL-Vita.git")
+url="https://github.com/rsn8887/SDL-Vita.git"
+source=("git://github.com/rsn8887/SDL-Vita.git")
 sha256sums=('SKIP')
 
 build() {


### PR DESCRIPTION
I am switching SDL2 to an updated repo on github. Cpasjuste and me have been updating SDL2 (and SDL12) for a while, and Xerpi's SDL-Vita repo is not being maintained anymore, as he said on IRC.

Most noticeable Vita-related changes:
- ScummVM crashes on startup when built with the "old" SDL2. It doesn't crash when built with the updated SDL2.
- Multi-controller support added for VitaTV (used by PFBA).
- Bugfixes
