### PR TITLE
fix libmad by using @cpasjuste's version that works

### DIFF
--- a/libmad/VITABUILD
+++ b/libmad/VITABUILD
@@ -1,25 +1,19 @@
 pkgname=libmad
 pkgver=0.15.1b
 pkgrel=1
-url="http://www.underbit.com/products/mad/"
-source=("http://download.sourceforge.net/mad/libmad-${pkgver}.tar.gz" "libmad-0.15.1b-Provide-Thumb-2-alternative-code-for-MAD_F_MLN.patch")
-sha256sums=('bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690' '9837191bc840a072f1b483a22ed07bbe6a78c41499dc290b9e701343f6c513b5')
-
-prepare() {
-  cd $pkgname-$pkgver
-  patch -Np1 -i "${srcdir}/libmad-0.15.1b-Provide-Thumb-2-alternative-code-for-MAD_F_MLN.patch"
-}
+url="https://github.com/cpasjuste/libmad-psp2"
+source=("git://github.com/cpasjuste/libmad-psp2.git#branch=master")
+sha256sums=('SKIP')
 
 build() {
-  cd $pkgname-$pkgver
-  export CFLAGS="${CFLAGS} -DHAVE_CONFIG_H -DHAVE_SYS_TYPES_H -DHAVE_ERRNO_H -DHAVE_UNISTD_H -DHAVE_FCNTL_H \
-	-ftree-vectorize -O3 -mword-relocations -fomit-frame-pointer -ffast-math \
-	-march=armv7-a -mtune=cortex-a9 -mfpu=neon -mfloat-abi=hard"
-  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static
+  cd libmad-psp2
+  make clean
   make
 }
 
 package () {
-  cd $pkgname-$pkgver
-  make DESTDIR=$pkgdir install
+  cd libmad-psp2
+  # hack: this install target ignores DESTDIR and uses VITASDK instead
+  mkdir -p $pkgdir/$VITASDK/arm-vita-eabi/{lib,include}
+  make VITASDK=$pkgdir/$VITASDK install
 }


### PR DESCRIPTION
From my tests with Scummvm, libmad from VitaSDK didn't work at all. It crashed everytime I tried to play an mp3. 

But @cpasjuste's version works just fine it seems.