### PR TITLE
libpng: update to 1.6.36

### DIFF
--- a/libpng/VITABUILD
+++ b/libpng/VITABUILD
@@ -1,9 +1,9 @@
 pkgname=libpng
-pkgver=1.6.32
+pkgver=1.6.36
 pkgrel=1
 url="http://www.libpng.org/pub/png/libpng.html"
 source=("http://download.sourceforge.net/libpng/libpng-${pkgver}.tar.gz")
-sha256sums=('1a8ae5c8eafad895cc3fce78fbcb6fdef663b8eb8375f04616e6496360093abb')
+sha256sums=('ca13c548bde5fb6ff7117cc0bdab38808acb699c0eccb613f0e4697826e1fd7d')
 
 build() {
   cd $pkgname-$pkgver


### PR DESCRIPTION
Fixes
error: IDAT: chunk data is too large
and iCCP warnings

see: https://sourceforge.net/p/libpng/bugs/270/

I found this while trying to load FIFA 15 icon in vita save manager and vita shell