### PR TITLE
curl: Hold specific commit for backward compatibility

### DIFF
--- a/curl/VITABUILD
+++ b/curl/VITABUILD
@@ -2,7 +2,7 @@ pkgname=curl
 pkgver=9999
 pkgrel=1
 url="https://github.com/d3m3vilurr/vita-curl"
-source=("git://github.com/d3m3vilurr/vita-curl.git")
+source=("git://github.com/d3m3vilurr/vita-curl.git#commit=c1138e50")
 sha256sums=('SKIP')
 
 build() {


### PR DESCRIPTION
[last commit][1] will enable `nonblock socket`.
but it requires [newlib pr][2].

after newlib pr, newlib socket will return `EAGAIN` instead
`SCE_NET_ERROR_EAGAIN`

this patch must revert after to merge newlib pr

[1]: https://github.com/d3m3vilurr/vita-curl/commit/45532a0a980d
[2]: https://github.com/vitasdk/newlib/pull/38