### PR TITLE
Add libtool to packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - cmake
       - cmake-data
       - texinfo # Contains makeinfo that is required to build libconfig
-      - libtool # Needed to build libtremor
+      - libtool-bin # Needed to build libtremor
 language: c
 compiler: clang
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - cmake
       - cmake-data
       - texinfo # Contains makeinfo that is required to build libconfig
+      - libtool # Needed to build libtremor
 language: c
 compiler: clang
 env:


### PR DESCRIPTION
libtool is needed to build libtremor

I tried to add the libsodium package but wasn't able to pass the travis-ci build step. So I fixed the issue causing the build to fail.