### PR TITLE
Bump up pkgrel for libk

### DIFF
--- a/libk/VITABUILD
+++ b/libk/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=libk
 pkgver=9999
-pkgrel=1
+pkgrel=2
 url="https://github.com/DaveeFTW/libk"
 source=("git://github.com/DaveeFTW/libk.git#branch=dev")
 sha256sums=('SKIP')


### PR DESCRIPTION
There have been some changes merged into https://github.com/DaveeFTW/libk/tree/dev, but the package at http://dl.vitasdk.org/libk.tar.xz does not yet contain them.

I believe it needs to be rebuilt.
I'm not sure if bumping up `pkgrel` is the way to go.