### PR TITLE
Switch to upstream SDL2_ttf

### DIFF
--- a/sdl2_ttf/VITABUILD
+++ b/sdl2_ttf/VITABUILD
@@ -1,19 +1,32 @@
 pkgname=sdl2_ttf
-pkgver=9999
-pkgrel=1
-url="https://github.com/rsn8887/SDL_ttf"
-source=("git://github.com/rsn8887/SDL_ttf.git")
-sha256sums=('SKIP')
+pkgver=2.0.15
+pkgrel=2
+gitrev=9d2a04f157c4e0c206fe5df7103018d5a59c6e35
+url="https://www.libsdl.org/projects/SDL_ttf/"
+source=(
+    "https://github.com/libsdl-org/SDL_ttf/archive/${gitrev}.zip"
+    "sdl-ttf-static.patch"
+)
+sha256sums=(
+    SKIP
+    bc7119a8bbfebbab0de774a7d671894be12ffed7d20f320d099de17d7baab2cb
+)
 depends=('sdl2 freetype')
 
+prepare() {
+  cd "SDL_ttf-${gitrev}"
+  patch --strip=1 --input="${srcdir}/sdl-ttf-static.patch"
+}
+
 build() {
-  cd SDL_ttf
-  make -j$(nproc) -f Makefile.vita
+  cd "SDL_ttf-${gitrev}"
+  mkdir build && cd build
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  make -j$(nproc)
 }
 
 package () {
-  cd SDL_ttf
-  # hack: this install target ignores DESTDIR and uses VITASDK instead
-  mkdir -p $pkgdir/$VITASDK/arm-vita-eabi/{lib,include}
-  make -f Makefile.vita VITASDK=$pkgdir/$VITASDK install 
+  cd "SDL_ttf-${gitrev}"
+  cd build
+  make DESTDIR=$pkgdir install
 }

--- a/sdl2_ttf/sdl-ttf-static.patch
+++ b/sdl2_ttf/sdl-ttf-static.patch
@@ -1,0 +1,33 @@
+From 24a07223cf0c32aa6d0604958522252c4ea11e5a Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sun, 2 May 2021 15:33:43 +0100
+Subject: [PATCH] CMake: Support static-only SDL2
+
+When SDL2 is built with `-DBUILD_SHARED_LIBS=OFF`, it does not define an
+`SDL2::SDL2` target.
+
+Use `SDL2::SDL2-static` and set `POSITION_INDEPENDENT_CODE`
+if `BUILD_SHARED_LIBS` is `OFF`.
+---
+ CMakeLists.txt | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 32aee5d..e9f1d26 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,7 +57,13 @@ set(SDL_TTF_VERSION "${SDL_TTF_MAJOR_VERSION}.${SDL_TTF_MINOR_VERSION}.${SDL_TTF
+ 
+ ##### library generation #####
+ add_library(SDL2_ttf SDL_ttf.c SDL_ttf.h)
+-target_link_libraries(SDL2_ttf SDL2::SDL2 Freetype::Freetype)
++if (BUILD_SHARED_LIBS)
++  target_link_libraries(SDL2_ttf SDL2::SDL2)
++else ()
++  target_link_libraries(SDL2_ttf SDL2::SDL2-static)
++  set_target_properties(SDL2_ttf PROPERTIES POSITION_INDEPENDENT_CODE ON)
++endif ()
++target_link_libraries(SDL2_ttf Freetype::Freetype)
+ target_include_directories(SDL2_ttf PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL2>)
+ 
+ install(


### PR DESCRIPTION
Git commit is targeted, because official release tarball somehow misses cmake config file.