### PR TITLE
Add libdl

### DIFF
--- a/libdl/VITABUILD
+++ b/libdl/VITABUILD
@@ -1,15 +1,10 @@
 pkgname=libdl
-pkgver=r1.bf46551
+pkgver=1
 pkgrel=1
 url="https://github.com/hyln9/vita-libdl"
 source=("git+https://github.com/hyln9/vita-libdl.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")
 sha256sums=('SKIP')
 depends=('taihen')
-
-pkgver() {
-  cd vita-libdl
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-}
 
 build() {
   cd vita-libdl

--- a/libdl/VITABUILD
+++ b/libdl/VITABUILD
@@ -4,6 +4,7 @@ pkgrel=1
 url="https://github.com/hyln9/vita-libdl"
 source=("git+https://github.com/hyln9/vita-libdl.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")
 sha256sums=('SKIP')
+depends=('taihen')
 
 pkgver() {
   cd vita-libdl

--- a/libdl/VITABUILD
+++ b/libdl/VITABUILD
@@ -1,5 +1,5 @@
 pkgname=libdl
-pkgver=1
+pkgver=9999
 pkgrel=1
 url="https://github.com/hyln9/vita-libdl"
 source=("git+https://github.com/hyln9/vita-libdl.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")

--- a/libdl/VITABUILD
+++ b/libdl/VITABUILD
@@ -1,0 +1,22 @@
+pkgname=libdl
+pkgver=r1.bf46551
+pkgrel=1
+url="https://github.com/hyln9/vita-libdl"
+source=("git+https://github.com/hyln9/vita-libdl.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd vita-libdl
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd vita-libdl
+  make PREFIX=$prefix
+}
+
+package () {
+  cd vita-libdl
+  make PREFIX=$prefix DESTDIR=$pkgdir install
+}
+

--- a/vita-libdl/VITABUILD
+++ b/vita-libdl/VITABUILD
@@ -1,18 +1,18 @@
-pkgname=libdl
+pkgname=vita-libdl
 pkgver=9999
 pkgrel=1
 url="https://github.com/hyln9/vita-libdl"
-source=("git+https://github.com/hyln9/vita-libdl.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")
+source=("git+https://github.com/hyln9/$pkgname.git#commit=bf46551882c344e5aebee07f15267e2ca93d78a5")
 sha256sums=('SKIP')
 depends=('taihen')
 
 build() {
-  cd vita-libdl
+  cd $pkgname
   make PREFIX=$prefix
 }
 
 package () {
-  cd vita-libdl
+  cd $pkgname
   make PREFIX=$prefix DESTDIR=$pkgdir install
 }
 


### PR DESCRIPTION
This is required to build lpp-vita. The repo on which it is based is archived, but it still builds.