### PR TITLE
Allow empty depends and makedepends fields

### DIFF
--- a/create-matrix.js
+++ b/create-matrix.js
@@ -52,7 +52,9 @@ directories.forEach(directory => {
         if (KV.length > 1 && (KV[0].trim() == 'depends' || KV[0].trim() == 'makedepends')) {
 
             const dependencies = KV[1].trim().replace("(", "").replace(")", "").replace(/\'||\)/g, "").split(' ');
-            dependant.set(directory, dependencies);
+            if (dependencies[0] != '') {
+                dependant.set(directory, dependencies);
+            }
 
             break;
         }


### PR DESCRIPTION
The script currently does not correctly see a VITABUILD as having no dependencies if it has ``depends=()`` in it. This makes it so if ``depends=`` is found in the file, but it doesn't contain anything, it will still be seen as a package without dependencies by the automated build system.