### PR TITLE
Migrate from sourceforge. Fixes #90

### DIFF
--- a/freetype/VITABUILD
+++ b/freetype/VITABUILD
@@ -1,9 +1,9 @@
 pkgname=freetype
-pkgver=2.9
+pkgver=2.9.1
 pkgrel=1
 url="https://www.freetype.org/"
-source=("http://downloads.sourceforge.net/project/freetype/freetype2/${pkgver}/freetype-${pkgver}.tar.gz")
-sha256sums=('bf380e4d7c4f3b5b1c1a7b2bf3abb967bda5e9ab480d0df656e0e08c5019c5e6')
+source=("https://download.savannah.gnu.org/releases/freetype/freetype-${pkgver}.tar.gz")
+sha256sums=('ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce')
 depends=('zlib')
 
 build() {

--- a/lame/VITABUILD
+++ b/lame/VITABUILD
@@ -2,18 +2,18 @@ pkgname=lame
 pkgver=3.100
 pkgrel=1
 url="https://lame.sourceforge.io/"
-source=("https://sourceforge.net/projects/lame/files/lame/$pkgver/lame-$pkgver.tar.gz")
-sha256sums=('ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e')
+source=("svn://svn.code.sf.net/p/lame/svn/trunk/lame#revision=r6403")
+sha256sums=('SKIP')
 
 build() {
-  cd $pkgname-$pkgver
+  cd lame
   export CFLAGS="-Wl,-q -O2 -ftree-vectorize -mfpu=neon -fomit-frame-pointer -ffast-math"
   export CXXFLAGS=$CFLAGS
-  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static --disable-frontend --enable-static --disable-gtktest
+  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static --disable-frontend --disable-gtktest
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver
+  cd lame
   make DESTDIR=$pkgdir install
 }

--- a/libjpeg-turbo/VITABUILD
+++ b/libjpeg-turbo/VITABUILD
@@ -2,22 +2,22 @@ pkgname=libjpeg-turbo
 pkgver=2.1.1
 pkgrel=1
 url="https://www.libjpeg-turbo.org/"
-source=("https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${pkgver}.tar.gz" "libjpeg-turbo.patch")
-sha256sums=('b76aaedefb71ba882cbad4e9275b30c2ae493e3195be0a099425b5c6b99bd510' 'SKIP')
+source=("git+https://github.com/libjpeg-turbo/libjpeg-turbo#tag=${pkgver}" "libjpeg-turbo.patch")
+sha256sums=('SKIP' 'SKIP')
 
 prepare() {
-  cd $pkgname-$pkgver
+  cd $pkgname
   patch -Np1 -i "${srcdir}/libjpeg-turbo.patch"
 }
 
 build() {
-  cd $pkgname-$pkgver
+  cd $pkgname
   mkdir build && cd build
   cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_SHARED=FALSE -DWITH_SIMD=FALSE
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver/build
+  cd $pkgname/build
   make DESTDIR=$pkgdir install
 }

--- a/libmpeg2/VITABUILD
+++ b/libmpeg2/VITABUILD
@@ -2,16 +2,16 @@ pkgname=libmpeg2
 pkgver=0.5.1
 pkgrel=1
 url="https://libmpeg2.sourceforge.io/"
-source=("https://libmpeg2.sourceforge.io/files/$pkgname-$pkgver.tar.gz")
-sha256sums=('dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4')
+source=("git+https://github.com/cisco-open-source/libmpeg2#tag=upstream/${pkgver}")
+sha256sums=('SKIP')
 
 build() {
-  cd $pkgname-$pkgver
-  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static --enable-arm-neon
+  cd $pkgname
+  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static --disable-sdl
   make
 }
 
 package() {
-  cd $pkgname-$pkgver
+  cd $pkgname
   make DESTDIR=$pkgdir install
 }

--- a/libpng/VITABUILD
+++ b/libpng/VITABUILD
@@ -2,17 +2,17 @@ pkgname=libpng
 pkgver=1.6.37
 pkgrel=1
 url="http://www.libpng.org/pub/png/libpng.html"
-source=("https://download.sourceforge.net/libpng/$pkgname-$pkgver.tar.gz")
-sha256sums=('daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4')
+source=("git+https://git.code.sf.net/p/libpng/code#tag=v$pkgver")
+sha256sums=('SKIP')
 depends=('zlib')
 
 build() {
-  cd $pkgname-$pkgver
+  cd code
   ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static --enable-arm-neon
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver
+  cd code
   make DESTDIR=$pkgdir install
 }


### PR DESCRIPTION
freetype and libjpeg-turbo switched to official mirrors.
I can't fine any better mirrors for libpng/lame/libmpeg2
