### PR TITLE
Add fribidi/libass. Fix harfbuzz pkg-config

### DIFF
--- a/fribidi/VITABUILD
+++ b/fribidi/VITABUILD
@@ -1,0 +1,27 @@
+pkgname=libfribidi
+pkgver=1.0.4
+pkgrel=1
+url="https://github.com/fribidi/fribidi"
+source=("https://github.com/fribidi/fribidi/releases/download/v$pkgver/fribidi-$pkgver.tar.bz2")
+sha256sums=('94bdfe553e004d8bd095b109e182682311dd511740d5083326d1582f1df237be')
+
+prepare() {
+  cd fribidi-$pkgver
+  # patch out binaries
+  sed '/^SUBDIRS/ s/bin //' -i Makefile.am
+  ./autogen.sh
+}
+
+build() {
+  cd fribidi-$pkgver
+
+  ./configure --host=arm-vita-eabi  --prefix=$VITASDK/arm-vita-eabi/ --disable-shared --enable-static
+
+  make -j$(nproc)
+}
+
+package() {
+  cd fribidi-$pkgver
+
+  make DESTDIR="$pkgdir" install
+}

--- a/harfbuzz/VITABUILD
+++ b/harfbuzz/VITABUILD
@@ -4,18 +4,15 @@ pkgrel=1
 url="http://harfbuzz.org/"
 source=("https://github.com/behdad/harfbuzz/releases/download/${pkgver}/harfbuzz-${pkgver}.tar.bz2")
 sha256sums=('ccec4930ff0bb2d0c40aee203075447954b64a8c2695202413cc5e428c907131')
-prepare() {
-  cd $pkgname-$pkgver
-}
+depends=('icu')
 
 build() {
   cd harfbuzz-$pkgver
-  mkdir build && cd build
-  cmake .. $CMARGS -DCMAKE_INSTALL_PREFIX=$prefix
+  CFLAGS=-lpthread ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static
   make -j$(nproc)
 }
 
 package () {
-  cd harfbuzz-$pkgver/build
+  cd harfbuzz-$pkgver
   make DESTDIR=$pkgdir install
 }

--- a/libass/VITABUILD
+++ b/libass/VITABUILD
@@ -1,0 +1,24 @@
+pkgname=libass
+pkgver=0.15.1
+pkgrel=1
+url="https://github.com/libass/libass"
+source=("https://github.com/libass/libass/releases/download/$pkgver/libass-$pkgver.tar.xz")
+sha256sums=('1cdd39c9d007b06e737e7738004d7f38cf9b1e92843f37307b24e7ff63ab8e53')
+depends=('freetype libpng harfbuzz fribidi')
+
+build() {
+  cd libass-$pkgver
+
+  ./configure --host=arm-vita-eabi  --prefix=$VITASDK/arm-vita-eabi/ \
+    --disable-shared --enable-static \
+    --disable-asm --enable-large-tiles \
+    --disable-require-system-font-provider
+
+  make
+}
+
+package() {
+  cd libass-$pkgver
+
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
harfbuzz build switched to autotools, due to cmake build missing pkg-config configs (and, generally, cmake build isn't supported by harfbuzz upstream).