### PR TITLE
Add initial vita asio-standalone port

### DIFF
--- a/asio/VITABUILD
+++ b/asio/VITABUILD
@@ -1,0 +1,24 @@
+pkgname=asio
+pkgver=1.19.2
+pkgrel=1
+_commit='ebeff99f539da23d27c2e8d4bdbc1ee011968644'
+url="https://think-async.com/Asio/"
+source=("git://github.com/diasurgical/${pkgname}.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+prepare() {
+    cd $pkgname/$pkgname
+    sed '/^SUBDIRS/ s/ src//' -i Makefile.am
+    ./autogen.sh
+}
+
+build() {
+  cd $pkgname/$pkgname
+  ./configure --host=arm-vita-eabi --prefix=$prefix
+  make
+}
+
+package () {
+  cd $pkgname/$pkgname
+  make DESTDIR=$pkgdir install
+}


### PR DESCRIPTION
Initial port of standalone (non-boostified) asio.
Not everything might work (like file and serial port stuff), but it's enough for network apps.