### PR TITLE
zlib: update to 1.2.12

### DIFF
--- a/zlib/VITABUILD
+++ b/zlib/VITABUILD
@@ -1,9 +1,9 @@
 pkgname=zlib
-pkgver=1.2.11
+pkgver=1.2.12
 pkgrel=1
 url="http://www.zlib.net/"
 source=("https://zlib.net/zlib-${pkgver}.tar.gz")
-sha256sums=('c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1')
+sha256sums=('91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9')
 
 build() {
   cd zlib-$pkgver


### PR DESCRIPTION
current 1.2.11 was deprecated and removed from zlib website