### PR TITLE
Add libxmp-lite

### DIFF
--- a/xmp-lite/VITABUILD
+++ b/xmp-lite/VITABUILD
@@ -1,0 +1,16 @@
+pkgname=xmp-lite
+pkgver=9999
+pkgrel=1
+url="https://github.com/bucanero/libxmp-lite-ps4"
+source=("git+https://github.com/bucanero/libxmp-lite-ps4.git")
+sha256sums=('SKIP')
+
+build() {
+  cd libxmp-lite-ps4
+  make -j$(nproc) -f Makefile.vita
+}
+
+package () {
+  cd libxmp-lite-ps4
+  make -f Makefile.vita install
+}

--- a/xmp-lite/VITABUILD
+++ b/xmp-lite/VITABUILD
@@ -1,8 +1,9 @@
 pkgname=xmp-lite
 pkgver=9999
 pkgrel=1
+gitrev=cce4d9ecb7c38eab6327e415a9134bdda5aa4170
 url="https://github.com/bucanero/libxmp-lite-ps4"
-source=("git+https://github.com/bucanero/libxmp-lite-ps4.git")
+source=("https://github.com/bucanero/libxmp-lite-ps4/archive/${gitrev}.tar.gz")
 sha256sums=('SKIP')
 
 build() {

--- a/xmp-lite/VITABUILD
+++ b/xmp-lite/VITABUILD
@@ -3,7 +3,7 @@ pkgver=9999
 pkgrel=1
 gitrev=cce4d9ecb7c38eab6327e415a9134bdda5aa4170
 url="https://github.com/bucanero/libxmp-lite-ps4"
-source=("https://github.com/bucanero/libxmp-lite-ps4/archive/${gitrev}.tar.gz")
+source=("git+https://github.com/bucanero/libxmp-lite-ps4.git#commit=${gitrev}")
 sha256sums=('SKIP')
 
 build() {


### PR DESCRIPTION
A simple port of libxmp-lite 4.5.0 for the vitasdk, as used on some Vita homebrews like ElevenMPV.