### PR TITLE
Add polarSSL library

### DIFF
--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -1,7 +1,7 @@
 pkgname=polarssl
 pkgver=1.3.9
 pkgrel=1
-url="https://polarssl.org"
+url="https://tls.mbed.org"
 source=("https://src.fedoraproject.org/repo/pkgs/polarssl/polarssl-1.3.9-gpl.tgz/48af7d1f0d5de512cbd6dacf5407884c/$pkgname-$pkgver-gpl.tgz")
 sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
 

--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -8,12 +8,11 @@ sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
 build() {
   cd $pkgname-$pkgver
   sed '84s/.*/defined(__arm__)/' library/net.c > library/net.c
-  cmake . --toolchain $VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+  cmake . --toolchain $VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE
   make -j$(nproc) polarssl
 }
 
 package () {
   cd $pkgname-$pkgver
-  cp library/libpolarssl.a "${VITASDK}/arm-vita-eabi/lib"
-  cp -R ../include/polarssl "${VITASDK}/arm-vita-eabi/include/polarssl"
+  make install
 }

--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -8,7 +8,7 @@ sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
 build() {
   cd $pkgname-$pkgver
   sed '84s/.*/defined(__arm__)/' library/net.c > library/net.c
-  cmake . --toolchain $VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE
+  cmake . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE
   make -j$(nproc) polarssl
 }
 

--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -14,5 +14,5 @@ build() {
 
 package () {
   cd $pkgname-$pkgver
-  make install
+  make DESTDIR=$pkgdir install
 }

--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -1,0 +1,19 @@
+pkgname=polarssl
+pkgver=1.3.9
+pkgrel=1
+url="https://polarssl.org"
+source=("https://src.fedoraproject.org/repo/pkgs/polarssl/polarssl-1.3.9-gpl.tgz/48af7d1f0d5de512cbd6dacf5407884c/$pkgname-$pkgver-gpl.tgz")
+sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
+
+build() {
+  cd $pkgname-$pkgver
+  sed '84s/.*/defined(__arm__)/' library/net.c > library/net.c
+  cmake . --toolchain $VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+  make -j$(nproc) polarssl
+}
+
+package () {
+  cd $pkgname-$pkgver
+  cp library/libpolarssl.a "${VITASDK}/arm-vita-eabi/lib"
+  cp -R ../include/polarssl "${VITASDK}/arm-vita-eabi/include/polarssl"
+}


### PR DESCRIPTION
I know that polarSSL has been replaced by mbedTLS, but I still use polarSSL for some projects (mostly for the hashing and crypto implementations).

This PR builds polarssl v1.3.9