### PR TITLE
Add libxmp and libxmp-lite

### DIFF
--- a/libxmp-lite/VITABUILD
+++ b/libxmp-lite/VITABUILD
@@ -1,0 +1,17 @@
+pkgname=libxmp-lite
+pkgver=4.5.0
+pkgrel=1
+url="https://github.com/libxmp/libxmp"
+source=("https://github.com/libxmp/libxmp/releases/download/libxmp-${pkgver}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('19a019abd5a3ddf449cd20ca52cfe18970f6ab28abdffdd54cff563981a943bb')
+
+build() {
+  cd $pkgname-$pkgver
+  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static
+  make -j$(nproc)
+}
+
+package () {
+  cd $pkgname-$pkgver
+  make DESTDIR=$pkgdir install
+}

--- a/libxmp/VITABUILD
+++ b/libxmp/VITABUILD
@@ -1,0 +1,22 @@
+pkgname=libxmp
+pkgver=4.5.0
+pkgrel=1
+url="https://github.com/libxmp/libxmp"
+source=("https://github.com/libxmp/libxmp/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz" "vita.patch")
+sha256sums=('7847d262112d14e8442f44e5ac6ed9ddbca54c251284720b563c852b31f26e75' '073398e2f87668981be410ca3a2f4e32fd09329346f9d7722a032e0b3783be71')
+
+prepare() {
+  cd $pkgname-$pkgver
+  patch -p1 < ../vita.patch
+}
+
+build() {
+  cd $pkgname-$pkgver
+  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static
+  make -j$(nproc)
+}
+
+package () {
+  cd $pkgname-$pkgver
+  make DESTDIR=$pkgdir install
+}

--- a/libxmp/vita.patch
+++ b/libxmp/vita.patch
@@ -1,0 +1,121 @@
+diff --git a/src/loaders/med2_load.c b/src/loaders/med2_load.c
+index 50e9c1a..ca6791f 100644
+--- a/src/loaders/med2_load.c
++++ b/src/loaders/med2_load.c
+@@ -28,6 +28,10 @@
+ #include <sys/syslimits.h>
+ #else
+ #include <limits.h>
++#ifndef PATH_MAX
++#define PATH_MAX 1024
++#endif
++
+ #endif
+ #include "loader.h"
+ #include "period.h"
+diff --git a/src/loaders/mfp_load.c b/src/loaders/mfp_load.c
+index 0dfe15e..3b2befd 100644
+--- a/src/loaders/mfp_load.c
++++ b/src/loaders/mfp_load.c
+@@ -32,6 +32,10 @@
+ #include <sys/syslimits.h>
+ #else
+ #include <limits.h>
++#ifndef PATH_MAX
++#define PATH_MAX 1024
++#endif
++
+ #endif
+ 
+ static int mfp_test(HIO_HANDLE *, char *, const int);
+diff --git a/src/loaders/mod_load.c b/src/loaders/mod_load.c
+index 2a3c894..def725d 100644
+--- a/src/loaders/mod_load.c
++++ b/src/loaders/mod_load.c
+@@ -37,6 +37,9 @@
+ 
+ #include <ctype.h>
+ #include <limits.h>
++#ifndef PATH_MAX
++#define PATH_MAX 1024
++#endif
+ #include "loader.h"
+ #include "mod.h"
+ 
+diff --git a/src/loaders/stm_load.c b/src/loaders/stm_load.c
+index 9c5aa63..e706e1e 100644
+--- a/src/loaders/stm_load.c
++++ b/src/loaders/stm_load.c
+@@ -23,6 +23,9 @@
+ #include <limits.h>
+ #include "loader.h"
+ #include "period.h"
++#ifndef PATH_MAX
++#define PATH_MAX 1024
++#endif
+ 
+ #define STM_TYPE_SONG	0x01
+ #define STM_TYPE_MODULE	0x02
+diff --git a/src/tempfile.c b/src/tempfile.c
+index 65a1081..6d4754b 100644
+--- a/src/tempfile.c
++++ b/src/tempfile.c
+@@ -96,6 +96,15 @@ static int get_temp_dir(char *buf, size_t size)
+ 	return 0;
+ }
+ 
++#elif defined __vita__
++
++static int get_temp_dir(char *buf, size_t size)
++{
++	strncpy(buf, "ux0:/data/tmp/", size);
++
++	return 0;
++}
++
+ #else /* unix */
+ 
+ static int get_temp_dir(char *buf, size_t size)
+@@ -113,6 +122,34 @@ static int get_temp_dir(char *buf, size_t size)
+ 
+ #endif
+ 
++#if defined __vita__
++#ifndef PATH_MAX
++#define PATH_MAX 1024
++#endif
++#include <string.h>
++
++FILE *make_temp_file(char **filename) {
++	char tmp[PATH_MAX];
++	char tmpfilename[128];
++	FILE *tempfd;
++
++	if (get_temp_dir(tmp, PATH_MAX) < 0)
++		return NULL;
++
++	snprintf(tmpfilename, 128, "xmp_%06x", rand() % 0xFFFFFF);
++	strncat(tmp, tmpfilename, PATH_MAX - 10);
++
++	if ((*filename = strdup(tmp)) == NULL)
++		return NULL;
++	if ((tempfd = fopen(tmp, "w+b")) == NULL)
++	{
++		free(*filename);
++	}
++
++	return tempfd;
++}
++
++#else
+ 
+ FILE *make_temp_file(char **filename) {
+ 	char tmp[PATH_MAX];
+@@ -145,6 +182,7 @@ FILE *make_temp_file(char **filename) {
+     err:
+ 	return NULL;
+ }
++#endif
+ 
+ /*
+  * Windows doesn't allow you to unlink an open file, so we changed the


### PR DESCRIPTION
Uses upstream 4.5.0
Replaces https://github.com/vitasdk/packages/pull/215 