### PR TITLE
Add fluidsynth-lite.

### DIFF
--- a/fluidsynth-lite/VITABUILD
+++ b/fluidsynth-lite/VITABUILD
@@ -1,0 +1,16 @@
+pkgname=fluidsynth-lite
+pkgver=9999
+pkgrel=1
+url="https://github.com/fgsfdsfgs/fluidsynth-lite"
+source=("git+https://github.com/fgsfdsfgs/fluidsynth-lite.git")
+sha256sums=('SKIP')
+
+build() {
+  cd $pkgname
+  make -f Makefile.vita -j$(nproc)
+}
+
+package () {
+  cd $pkgname
+  make -f Makefile.vita DESTDIR=$pkgdir install
+}

--- a/fluidsynth-lite/VITABUILD
+++ b/fluidsynth-lite/VITABUILD
@@ -12,5 +12,5 @@ build() {
 
 package () {
   cd $pkgname
-  make -f Makefile.vita DESTDIR=$pkgdir install
+  make -f Makefile.vita DESTDIR=$pkgdir/$prefix install
 }


### PR DESCRIPTION
FluidLite randomly crashes with Doom64EX so having fluidsynth-lite may be worthy for other projects other than Doom64EX itself that may encounter same problematics.

FluidLite and fluidsynth-lite don't clash in any way since both libraries and headers are separate (libfluidlite.a vs libfluidsynth.a, fluidlite.h vs fluidsynth.h and include/fluidlite vs include/fluidsynth).