### PR TITLE
Switch to termux/upload-release-action, fix deprecated set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: node:lts
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         id: set-matrix
         run: |
@@ -34,7 +34,7 @@ jobs:
       SSHPASS: ${{ secrets.SSHPASS }}
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -54,7 +54,7 @@ jobs:
       run: |
         export FILE=`echo ${{ matrix.package }}/*-arm.tar.xz`
         mv $FILE ${{ matrix.package }}/${{ matrix.package }}.tar.xz
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: package
         path: ${{ matrix.package }}/*.tar.xz
@@ -70,8 +70,8 @@ jobs:
       SSHPASS: ${{ secrets.SSHPASS }}
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -100,7 +100,7 @@ jobs:
       run: |
         export FILE=`echo ${{ env.PACKAGE }}/*-arm.tar.xz`
         mv $FILE ${{ env.PACKAGE }}/${{ env.PACKAGE }}.tar.xz
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: package
         path: ${{ env.PACKAGE }}/*.tar.xz
@@ -108,8 +108,8 @@ jobs:
       needs: [prepare_jobs, build, build_depends]
       runs-on: ubuntu-18.04
       steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libarchive-tools
-      - uses: termux/upload-release-action@v4.0.1
+      - uses: termux/upload-release-action@v3.0.3
         if: contains(github.ref,'refs/heads/master')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install dependencies
         id: set-matrix
         run: |
-          echo "::set-output name=dependant::$(node create-matrix.js dependant)"
-          echo "::set-output name=non_dependant::$(node create-matrix.js non_dependant)"
+          echo "dependant=$(node create-matrix.js dependant)" >> $GITHUB_OUTPUT
+          echo "non_dependant=$(node create-matrix.js non_dependant)" >> $GITHUB_OUTPUT
     outputs:
       dependant: ${{ steps.set-matrix.outputs.dependant }}
       non_dependant: ${{ steps.set-matrix.outputs.non_dependant }}
@@ -114,12 +114,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libarchive-tools
-      - uses: svenstaro/upload-release-action@v2
+      - uses: termux/upload-release-action@v4.0.1
         if: contains(github.ref,'refs/heads/master')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: package/*.tar.xz
           overwrite: true
           file_glob: true
-          tag: ${{ github.ref }}        
+          tag: ${{ github.ref }}
           release_name: master


### PR DESCRIPTION
* Switch to maintained termux/upload-release-action
* fix deprecated set-output (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)