### PR TITLE
box2d: use CMAKE_TOOLCHAIN_FILE instead of $CMARGS

### DIFF
--- a/box2d/VITABUILD
+++ b/box2d/VITABUILD
@@ -8,8 +8,8 @@ sha256sums=('SKIP')
 build() {
   cd box2d-$pkgver
   mkdir build && cd build
-  cmake .. $CMARGS -DCMAKE_INSTALL_PREFIX=$prefix \
-    -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_TESTBED=OFF
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix \
+    -DCMAKE_BUILD_TYPE=Release -DBOX2D_BUILD_DOCS=OFF -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_TESTBED=OFF
   make -j$(nproc)
 }
 


### PR DESCRIPTION
https://github.com/vitasdk/vita-makepkg/blob/0c7da211ef88d7dc5339288e69f41c3950b8b3d2/makepkg.conf.sample#L43-L44
