### PR TITLE
Do not link SDL2_mixer to libxmp, because LGPL

### DIFF
--- a/libxmp-lite/VITABUILD
+++ b/libxmp-lite/VITABUILD
@@ -1,17 +1,19 @@
 pkgname=libxmp-lite
-pkgver=4.5.0
+pkgver=4.6.0
 pkgrel=1
 url="https://github.com/libxmp/libxmp"
 source=("https://github.com/libxmp/libxmp/releases/download/libxmp-${pkgver}/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('19a019abd5a3ddf449cd20ca52cfe18970f6ab28abdffdd54cff563981a943bb')
+sha256sums=('71a93eb0119824bcc56eca95db154d1cdf30304b33d89a4732de6fef8a2c6f38')
 
 build() {
   cd $pkgname-$pkgver
-  ./configure --host=arm-vita-eabi --prefix=$prefix --disable-shared --enable-static
+  mkdir -p build && cd build
+  cmake -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=OFF ..
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver
+  cd $pkgname-$pkgver/build
   make DESTDIR=$pkgdir install
 }

--- a/sdl2_mixer/VITABUILD
+++ b/sdl2_mixer/VITABUILD
@@ -1,28 +1,32 @@
 pkgname=sdl2_mixer
 pkgver=2.6.3
-pkgrel=1
+pkgrel=2
 url="https://github.com/libsdl-org/SDL_mixer"
 source=("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${pkgver}.tar.gz"
-        "pkg-config-fix.patch")
+        "pkg-config-fix.patch"
+        "libxmp-lite-fix.patch")
 sha256sums=(
     "7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
     "9de77978b881b0ab61aa60673ec7de92e920f8affd42ab129d8fe153e2698de5"
+    "3dc9b332adb6b08af12c7e5e4aa3b0165c9ef4ed3e6d7e8b2f1a57a83118ad2d"
 )
 
-depends=('sdl2' 'libvorbis' 'libxmp' 'libmodplug' 'mpg123' 'flac' 'opusfile')
+depends=('sdl2' 'libvorbis' 'libxmp-lite' 'libmodplug' 'mpg123' 'flac' 'opus')
 
 prepare() {
   cd "SDL2_mixer-${pkgver}"
   patch --strip=1 --input="${srcdir}/pkg-config-fix.patch"
+  patch --strip=1 --input="${srcdir}/libxmp-lite-fix.patch"
 }
 
 build() {
   cd "SDL2_mixer-${pkgver}"
-  mkdir build && cd build
+  mkdir -p build && cd build
   cmake -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_SHARED_LIBS=OFF \
         -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2MIXER_DEPS_SHARED=OFF -DSDL2MIXER_OPUS=ON -DSDL2MIXER_MIDI=ON \
-        -DSDL2MIXER_MIDI_TIMIDITY=ON -DSDL2MIXER_FLAC=ON -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_MOD_XMP=ON -DSDL2MIXER_MP3_MPG123=ON \
-        -DSDL2MIXER_MOD_MODPLUG=ON -DSDL2MIXER_CMD=OFF -DSDL2MIXER_MIDI_FLUIDSYNTH=OFF -DSDL2MIXER_SAMPLES=OFF ..
+        -DSDL2MIXER_MIDI_TIMIDITY=ON -DSDL2MIXER_FLAC=ON -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_MOD_XMP=ON -DSDL2MIXER_MP3_MPG123=OFF \
+        -DSDL2MIXER_MOD_MODPLUG=ON -DSDL2MIXER_MOD_XMP_LITE=ON -DSDL2MIXER_CMD=OFF -DSDL2MIXER_MIDI_FLUIDSYNTH=OFF \
+        -DSDL2MIXER_MP3_DRMP3=ON -DSDL2MIXER_MP3=ON -DSDL2MIXER_SAMPLES=OFF -DSDL2MIXER_MOD_XMP_SHARED=OFF ..
   make -j$(nproc)
 }
 

--- a/sdl2_mixer/VITABUILD
+++ b/sdl2_mixer/VITABUILD
@@ -11,7 +11,7 @@ sha256sums=(
     "3dc9b332adb6b08af12c7e5e4aa3b0165c9ef4ed3e6d7e8b2f1a57a83118ad2d"
 )
 
-depends=('sdl2' 'libvorbis' 'libxmp-lite' 'libmodplug' 'mpg123' 'flac' 'opus')
+depends=('sdl2' 'libvorbis' 'libxmp-lite' 'libmodplug' 'mpg123' 'flac' 'opusfile')
 
 prepare() {
   cd "SDL2_mixer-${pkgver}"

--- a/sdl2_mixer/libxmp-lite-fix.patch
+++ b/sdl2_mixer/libxmp-lite-fix.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54317572..2d5baaaa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -589,10 +589,10 @@ if(SDL2MIXER_MOD_XMP)
+     if(SDL2MIXER_MOD_XMP_LITE)
+         message(STATUS "Using system libxmp-lite")
+         find_package(libxmp-lite REQUIRED)
+-        set(tgt_xmp libxmp-lite::libxmp-lite)
++        set(tgt_xmp libxmp-lite)
+         set(xmp_name libxmp-lite)
+         if(NOT SDL2MIXER_MOD_XMP_SHARED)
+-            list(APPEND PC_REQUIRES libxmplite)
++            list(APPEND PC_REQUIRES libxmp-lite)
+         endif()
+     else()
+         message(STATUS "Using system libxmp")
+diff --git a/cmake/Findlibxmp-lite.cmake b/cmake/Findlibxmp-lite.cmake
+index d0b2bbbb..911ed77b 100644
+--- a/cmake/Findlibxmp-lite.cmake
++++ b/cmake/Findlibxmp-lite.cmake
+@@ -1,9 +1,10 @@
+ find_library(libxmp_lite_LIBRARY
+-    NAMES xmp
++    NAMES xmp-lite
+ )
+ 
+ find_path(libxmp_lite_INCLUDE_PATH
+     NAMES xmp.h
++    PATH_SUFFIXES libxmp-lite
+ )
+ 
+ set(libxmp_lite_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp_lite")
+@@ -12,20 +13,19 @@ set(libxmp_lite_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp_l
+ 
+ set(libxmp_lite_LINK_FLAGS "" CACHE STRING "Extra link flags of libxmp_lite")
+ 
+-find_package_handle_standard_args(libxmp_lite
++find_package_handle_standard_args(libxmp-lite
+     REQUIRED_VARS libxmp_lite_LIBRARY libxmp_lite_INCLUDE_PATH
+ )
+ 
+ if(libxmp_lite_FOUND)
+     if(NOT TARGET libxmp-lite::libxmp-lite)
+         add_library(libxmp-lite::libxmp-lite UNKNOWN IMPORTED)
+-        set_target_properties(libxmp_lite::libxmp_lite-shared PROPERTIES
++        set_target_properties(libxmp_lite::libxmp_lite PROPERTIES
+             IMPORTED_LOCATION "${libxmp_lite_LIBRARY}"
+             INTERFACE_INCLUDE_DIRECTORIES "${libxmp_lite_INCLUDE_PATH}"
+             INTERFACE_COMPILE_OPTIONS "${libxmp_lite_COMPILE_OPTIONS}"
+             INTERFACE_LINK_LIBRARIES "${libxmp_lite_LINK_LIBRARIES}"
+             INTERFACE_LINK_FLAGS "${libxmp_lite_LINK_FLAGS}"
+         )
+-        endif()
+     endif()
+ endif()


### PR DESCRIPTION
I've changed it to libxmp-lite now, which is MIT licensed instead of LGPL. Building SDL2_mixer with libxmp-lite was kinda broken, so I had to patch it. I've tested it and SDL2_mixer still seems to work like expected