### PR TITLE
libvita2d: replace hardcoded path with pkg-config

### DIFF
--- a/libvita2d/VITABUILD
+++ b/libvita2d/VITABUILD
@@ -8,7 +8,7 @@ depends=('zlib' 'libpng' 'libjpeg-turbo' 'freetype')
 
 build() {
   cd $pkgname/$pkgname
-  make -j$(nproc) CFLAGS='-Wl,-q -Wall -O3 -I$(INCLUDES) -I$(VITASDK)/arm-vita-eabi/include/freetype2' # lto is broken on Windows vita-gcc for some reason
+  make -j$(nproc) CFLAGS='-Wl,-q -Wall -O3 -I$(INCLUDES) $(shell arm-vita-eabi-pkg-config --cflags freetype2)' # lto is broken on Windows vita-gcc for some reason
 }
 
 package () {


### PR DESCRIPTION
This PR replaces a hardcoded freetype2 include path in libvita2d/VITABUILD with a call to arm-vita-eabi-pkg-config. This does not matter for the default build, but it does matter if/when freetype2 is installed in a different prefix.