### PR TITLE
minizip: Re-enable MZ_COMPAT, patch out zip.h

### DIFF
--- a/minizip/VITABUILD
+++ b/minizip/VITABUILD
@@ -10,12 +10,13 @@ prepare() {
   cd minizip-ng-$pkgver
   patch -p1 < ../no-pic.patch
   patch -p1 < ../no-symlink.patch
+  patch -p1 < ../no-zip_h.patch
 }
 
 build() {
   cd minizip-ng-$pkgver
   mkdir build && cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DMZ_COMPAT=OFF -DMZ_LZMA=OFF -DUNIX=ON
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DMZ_COMPAT=ON -DMZ_LZMA=OFF -DUNIX=ON
   make -j$(nproc)
 }
 

--- a/minizip/no-zip_h.patch
+++ b/minizip/no-zip_h.patch
@@ -1,0 +1,22 @@
+--- a/CMakeLists.txt	2023-05-19 10:27:46.000000000 -0400
++++ b/CMakeLists.txt	2023-08-21 11:07:53.676439915 -0400
+@@ -607,10 +607,6 @@
+ 
+ # Include compatibility layer
+ if(MZ_COMPAT)
+-    set(FILE_H "zip.h")
+-    set(MZ_COMPAT_FILE "MZ_COMPAT_ZIP")
+-    configure_file(mz_compat_shim.h.in zip.h)
+-
+     set(FILE_H "unzip.h")
+     set(MZ_COMPAT_FILE "MZ_COMPAT_UNZIP")
+     configure_file(mz_compat_shim.h.in unzip.h)
+@@ -619,7 +615,7 @@
+         list(APPEND MINIZIP_DEF -DMZ_COMPAT_VERSION=${MZ_COMPAT_VERSION})
+     endif()
+     list(APPEND MINIZIP_SRC mz_compat.c)
+-    list(APPEND MINIZIP_HDR mz_compat.h ${CMAKE_CURRENT_BINARY_DIR}/zip.h ${CMAKE_CURRENT_BINARY_DIR}/unzip.h)
++    list(APPEND MINIZIP_HDR mz_compat.h ${CMAKE_CURRENT_BINARY_DIR}/unzip.h)
+ endif()
+ 
+ # Set compiler options


### PR DESCRIPTION
This restores minizip 1.0 compatibility via "unzip.h", while avoiding the issue where MZ_COMPAT would generate and install a "zip.h" header, overwriting libzip's.