### PR TITLE
Fix duplicate deps

### DIFF
--- a/create-matrix.js
+++ b/create-matrix.js
@@ -79,7 +79,10 @@ directories.forEach(library => {
         const deps = [];
         dependencies.forEach((dependency) => {
             if (dependant.get(dependency))
-                deps.push(dependency);
+            {
+                if (!deps.includes(dependency))
+                    deps.push(dependency);
+            }
         });
         deps.forEach(dependency => info = dependency + " " + info);
         output.dependant.push(info);


### PR DESCRIPTION
Prevent listing dependencies more than once (e.g. https://github.com/vitasdk/packages/actions/runs/5986280549/job/16239408765 when libpng is built five times)

Re-run workflow and merge *after* issues with cpython3 are fixed.