### PR TITLE
sdl2_mixer_ext: use libvorbis instead of stb

### DIFF
--- a/sdl2_mixer_ext/VITABUILD
+++ b/sdl2_mixer_ext/VITABUILD
@@ -10,7 +10,7 @@ depends=('sdl2' 'libvorbis' 'libxmp' 'libmodplug' 'mpg123' 'flac' 'opusfile')
 build() {
   cd SDL-Mixer-X-${pkgver}
   mkdir build && cd build
-  cmake .. -DVITA=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  cmake .. -DVITA=1 -DUSE_OGG_VORBIS_STB=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
   make -j$(nproc)
 }
 


### PR DESCRIPTION
stb ogg decoder that the library fallbacks to by default is buggy, here we use the built-in switch to use libvorbis for that instead. tested to be working and having less issues