### PR TITLE
github: Reduce package installing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
+    # TODO only download deps
     - uses: actions/download-artifact@v3
     - name: Install dependencies
       run: |
@@ -78,18 +79,11 @@ jobs:
     - name: Prepare Build
       run: |
         bash ./prepare.sh
-    - name: Install packages
+    - name: Install and Build packages
       run: |
         export VITASDK=/usr/local/vitasdk
         export PATH=$(pwd)/../vita-makepkg:$VITASDK/bin:$PATH
-        cd package
-        for f in *.tar.xz; do tar -C $VITASDK/arm-vita-eabi/ -xvf "$f"; done
-        cd ..
-    - name: Build packages
-      run: |
-        export VITASDK=/usr/local/vitasdk
-        export PATH=$(pwd)/../vita-makepkg:$VITASDK/bin:$PATH
-        for f in ${{ matrix.package }}; do bash ./build.sh $f; done
+        for f in ${{ matrix.package }}; do bash ./install_or_build.sh $f; done
     - name: Export package
       run: |
         export PACKAGE=`echo ${{ matrix.package }} | awk '{print $NF}'`

--- a/ALmixer/VITABUILD
+++ b/ALmixer/VITABUILD
@@ -4,7 +4,7 @@ pkgrel=1
 url="https://github.com/Rinnegatamante/ALmixer"
 source=("https://github.com/Rinnegatamante/$pkgname/archive/$pkgver.tar.gz")
 sha256sums=('57e81731197bba8d56e2cd279d80a2a8ee6629ad8b194dd051d9acba49630f49')
-depends=('libvorbis' 'mpg123' 'libogg')
+depends=('libvorbis' 'mpg123' 'libogg' 'openal-soft')
 
 build() {
   cd $pkgname-$pkgver

--- a/cpython3/VITABUILD
+++ b/cpython3/VITABUILD
@@ -6,10 +6,6 @@ source=("git+https://github.com/SonicMastr/cpython-vita.git")
 sha256sums=('SKIP')
 depends=('openssl-1.1.1 libzip xz zlib bzip2')
 
-prepare() {
-  vdpm openssl-1.1.1
-}
-
 build() {
   echo ""
 }

--- a/curl/VITABUILD
+++ b/curl/VITABUILD
@@ -4,7 +4,7 @@ pkgrel=1
 url="https://github.com/d3m3vilurr/vita-curl"
 source=("git+https://github.com/d3m3vilurr/vita-curl.git")
 sha256sums=('SKIP')
-depends=('openssl')
+depends=('openssl' 'zlib')
 
 build() {
   cd vita-curl

--- a/install_or_build.sh
+++ b/install_or_build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [ -f "./package/$1.tar.xz" ];
+then
+    tar -C $VITASDK/arm-vita-eabi/ -xvf "./package/$1.tar.xz"
+else
+    bash ./build.sh $1
+fi

--- a/openssl-1.1.1/VITABUILD
+++ b/openssl-1.1.1/VITABUILD
@@ -16,5 +16,5 @@ package () {
   cd vita-openssl3
   printf '#!/bin/bash\nmkdir -p $@\n' > util/mkdir-p.pl
   make DESTDIR=$pkgdir install
-  rm -rf $pkgdir/$prefix/ssl/man # remove useless man pages
+  rm -rf $pkgdir/$prefix/share # remove useless man pages
 }

--- a/sdl_net/VITABUILD
+++ b/sdl_net/VITABUILD
@@ -5,7 +5,7 @@ url="https://github.com/libsdl-org/SDL_net/"
 gitrev=283e95e3460e8caca7ffacef4b94d82a80e8700f
 source=("https://github.com/libsdl-org/SDL_net/archive/${gitrev}.tar.gz" "vita.patch")
 sha256sums=('SKIP' 'SKIP')
-depends=('sdl2')
+depends=('sdl')
 
 prepare() {
   cd "SDL_net-${gitrev}"


### PR DESCRIPTION
- introduce new script install_or_build.sh
- remake dep resolver
- fix various dependency errors

TODO
- this chain will make same pkg multiple files if a pkg have deps
- script doesn't check the dep conflict
  for example, python uses openssl-1.1.1 and libzip, but libzip
  has openssl dep.
  we should support optional dep for this.
- some action should move to vdpm

this patch will replace #291 