### PR TITLE
Remove explicit git checkout calls from VITABUILDs

### DIFF
--- a/cpython3/VITABUILD
+++ b/cpython3/VITABUILD
@@ -2,7 +2,7 @@ pkgname=cpython
 pkgver=3.11
 pkgrel=1
 url="https://github.com/SonicMastr/cpython-vita"
-source=("git+https://github.com/SonicMastr/cpython-vita.git")
+source=("git+https://github.com/SonicMastr/cpython-vita.git#branch=3.11")
 sha256sums=('SKIP')
 depends=('openssl-1.1.1 libzip xz zlib bzip2')
 
@@ -12,7 +12,6 @@ build() {
 
 package () {
   cd cpython-vita
-  git checkout 3.11
   sh build_vita.sh $pkgdir
   sh compile_modules_vita.sh $pkgdir
   rm -rf $pkgdir/$prefix/bin

--- a/openssl-1.1.1/VITABUILD
+++ b/openssl-1.1.1/VITABUILD
@@ -2,12 +2,11 @@ pkgname=openssl-1.1.1
 pkgver=1.1.1
 pkgrel=1
 url="https://github.com/SonicMastr/vita-openssl3"
-source=("git+https://github.com/SonicMastr/vita-openssl3.git")
+source=("git+https://github.com/SonicMastr/vita-openssl3.git#branch=OpenSSL_1_1_1-vita")
 sha256sums=('SKIP')
 
 build() {
   cd vita-openssl3
-  git checkout OpenSSL_1_1_1-vita
   ./Configure --prefix=$VITASDK/arm-vita-eabi/ no-asm no-pic no-unit-test no-shared vita-cross
   make -j$(nproc)
 }


### PR DESCRIPTION
Instead, specify the desired branch on inside the git+https pseudo-URL and let vita-makepkg check out the branch on its own.