### PR TITLE
sdl2_mixer: Fix pkg-config error because of libxmp-lite

### DIFF
--- a/sdl2_mixer/VITABUILD
+++ b/sdl2_mixer/VITABUILD
@@ -1,7 +1,7 @@
 pkgname=sdl2_mixer
 pkgver=2.6.99
-pkgrel=1
-gitrev=eb005518b0085244630ccfb41977f818af45d2ea
+pkgrel=2
+gitrev=656a45a604bbdd23ebceb9067fb67d1bc3b5bcc5
 url="https://github.com/libsdl-org/SDL_mixer"
 source=("git+https://github.com/libsdl-org/SDL_mixer.git#commit=${gitrev}"
         "pkg-config-fix.patch"


### PR DESCRIPTION
I managed to get the error I found fixed with this PR: https://github.com/libsdl-org/SDL_mixer/pull/575

Merging this closes https://github.com/vitasdk/packages/issues/301