### PR TITLE
xz: Change package link temporary.

### DIFF
--- a/xz/VITABUILD
+++ b/xz/VITABUILD
@@ -2,7 +2,7 @@ pkgname=xz
 pkgver=5.4.3
 pkgrel=1
 url="https://tukaani.org/xz/"
-source=("https://tukaani.org/${pkgname}/${pkgname}-${pkgver}.tar.gz")
+source=("https://jaist.dl.sourceforge.net/project/lzmautils/${pkgname}-${pkgver}.tar.gz")
 sha256sums=('1c382e0bc2e4e0af58398a903dd62fff7e510171d2de47a1ebe06d1528e9b7e9')
 
 build() {


### PR DESCRIPTION
we don't need to update xz to upstream link or downgrade link. but repo was closed in github and it makes trouble to our CI