### PR TITLE
Fix generation of artifact dependencies to download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Generate actions/download-artifact pattern
       id: generate-download-artifact-pattern
       run: |
-        PATTERN=`echo ${{ matrix.package }} | awk 'NF{NF-=1};1' | tr ' ' ',' | awk '{ print "{" $0 "}" }'`
+        PATTERN=`echo ${{ matrix.package }} | awk 'NF{NF-=1};1' | tr ' ' '|' | awk '{ print "@(" $0 ")" }'`
         echo "PATTERN=$PATTERN" >> $GITHUB_OUTPUT
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Current pattern does not work with one dependency, that's why `build_depends (openssl minizip)` fails because openssl artifact is not downloaded.
It will work correctly with this new pattern