### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,3 +126,4 @@ jobs:
           file_glob: true
           tag: ${{ github.ref }}
           release_name: master
+          checksums: sha256

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.package }}
-        path: ${{ matrix.package }}/*.tar.xz
+        path: ${{ matrix.package }}/${{ matrix.package }}.tar.xz
   build_depends:
     needs: [prepare_jobs, build]
     runs-on: ubuntu-20.04
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.PACKAGE }}
-        path: ${{ env.PACKAGE }}/*.tar.xz
+        path: ${{ env.PACKAGE }}/${{ env.PACKAGE }}.tar.xz
   upload-releases:
       needs: [prepare_jobs, build, build_depends]
       runs-on: ubuntu-20.04


### PR DESCRIPTION
Hopefully this will be the last fix to have the CI all green.

It seems the GitHub action termux/upload-release-action requires, in its latest version, to provide a checksum value to work. This will generate (and upload) a file named `CHECKSUMS-sha256.txt` with a checksum for all artifacts.

I also found an issue with the uploaded artifacts (using actions/upload-artifact@v4). If the source package is a file with the tar.xz extension, it will be uploaded with the generated package. This is not wanted so I added an extra restriction to fix it. It will prevent this as seen in the release (https://github.com/vitasdk/packages/releases):
![image](https://github.com/user-attachments/assets/f48e72e8-80fc-4bc3-83d2-d87c50953fce)

Tested on my fork, the release can be seen here https://github.com/scribam/packages/releases/tag/master and the last action here https://github.com/scribam/packages/actions/runs/10161076933

Sorry for the inconvenience related to my different changes