### PR TITLE
Add uvdb package

### DIFF
--- a/kubridge/VITABUILD
+++ b/kubridge/VITABUILD
@@ -1,8 +1,8 @@
 pkgname=kubridge
 pkgver=9999
-pkgrel=1
-url="https://github.com/TheOfficialFloW/kubridge"
-source=("git+https://github.com/TheOfficialFloW/kubridge.git")
+pkgrel=2
+url="https://github.com/bythos14/kubridge"
+source=("git+https://github.com/bythos14/kubridge.git#commit=a4ef20fc3ab07b493f9d7d67703272831e445e21")
 sha256sums=('SKIP')
 depends=('taihen')
 

--- a/uvdb/VITABUILD
+++ b/uvdb/VITABUILD
@@ -1,0 +1,19 @@
+pkgname=uvdb
+pkgver=0.1
+pkgrel=1
+url="https://github.com/sleirsgoevy/vita-uvdb"
+source=("git+https://github.com/sleirsgoevy/vita-uvdb.git#tag=v$pkgver")
+sha256sums=('SKIP')
+depends=('kubridge')
+
+build() {
+  cd vita-uvdb
+  make -j$(nproc)
+}
+
+package () {
+  cd vita-uvdb
+  mkdir -p $pkgdir/$VITASDK/arm-vita-eabi/{include,lib}
+  cp libuvdb.a $pkgdir/$VITASDK/arm-vita-eabi/lib
+  cp uvdb.h $pkgdir/$VITASDK/arm-vita-eabi/include
+}


### PR DESCRIPTION
See https://github.com/sleirsgoevy/vita-uvdb

This is just something I made during the last few days. I hope that some people will find it useful, and having it directly in the SDK will make it easier for other developers to use it.

kubridge is changed to point to bythos14's fork, since I need several functions that are not present in the abandoned upstream version, and that fork is the version everyone is actually using anyway.