### PR TITLE
sdl2_image: Add libwebpdemux to pkgconf file

### DIFF
--- a/sdl2_image/VITABUILD
+++ b/sdl2_image/VITABUILD
@@ -1,11 +1,11 @@
 pkgname=sdl2_image
 pkgver=2.8.2
-pkgrel=1
+pkgrel=2
 url="https://github.com/libsdl-org/SDL_image"
 source=("https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${pkgver}.tar.gz"
 	"pkg-config-fix.patch")
 sha256sums=("8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc"
-            "a35580ce63abb881753d5751c1fdb61c4276ddce1253125654d9a8b082a1aa58")
+            "75253d108fa60f98b44493f4877061ba3e87106e7ae345b8be08841d138ef220")
 depends=('sdl2 libpng libwebp libjpeg-turbo zlib')
 
 prepare() {

--- a/sdl2_image/pkg-config-fix.patch
+++ b/sdl2_image/pkg-config-fix.patch
@@ -1,3 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 65a8811..bc439d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -691,7 +691,7 @@ if(SDL2IMAGE_WEBP)
+     else()
+         message(STATUS "${PROJECT_NAME}: Using system libwebp")
+         find_package(webp REQUIRED)
+-        list(APPEND PC_REQUIRES libwebp)
++        list(APPEND PC_REQUIRES libwebp libwebpdemux)
+     endif()
+     if(SDL2IMAGE_WEBP_SHARED)
+         target_include_directories(SDL2_image PRIVATE
 diff --git a/SDL2_image.pc.in b/SDL2_image.pc.in
 index 8711dd7..cf6b501 100644
 --- a/SDL2_image.pc.in


### PR DESCRIPTION
Without this linking will fail when using pkgconf. here is an example: https://github.com/sharkwouter/oceanpop/actions/runs/11243696277/job/31260185313

```
[ 85%] Linking CXX executable oceanpop
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: /usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/lib/libSDL2_image.a(IMG_webp.c.obj): in function `IMG_InitWEBP':
(.text+0xec): undefined reference to `WebPDemuxInternal'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0xf4): undefined reference to `WebPDemuxInternal'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0xfc): undefined reference to `WebPDemuxGetFrame'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0x100): undefined reference to `WebPDemuxGetI'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0x104): undefined reference to `WebPDemuxGetFrame'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0x108): undefined reference to `WebPDemuxGetI'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0x118): undefined reference to `WebPDemuxDelete'
/usr/local/vitasdk/bin/../lib/gcc/arm-vita-eabi/10.3.0/../../../../arm-vita-eabi/bin/ld: (.text+0x11e): undefined reference to `WebPDemuxDelete'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/oceanpop.dir/build.make:449: oceanpop] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:89: CMakeFiles/oceanpop.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

I also fixed this upstream: https://github.com/libsdl-org/SDL_image/pull/473