### PR TITLE
sdl2: update package to latest Git version

### DIFF
--- a/sdl2/VITABUILD
+++ b/sdl2/VITABUILD
@@ -1,12 +1,19 @@
 pkgname=sdl2
 pkgver=2.30.9
-pkgrel=1
+pkgrel=2
 url='https://www.libsdl.org'
-source=("https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL2-${pkgver}.tar.gz")
-sha256sums=('24b574f71c87a763f50704bbb630cbe38298d544a1f890f099a4696b1d6beba4')
+source=(
+    "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL2-${pkgver}.tar.gz"
+    "https://github.com/libsdl-org/SDL/pull/11442.patch"
+)
+sha256sums=(
+    '24b574f71c87a763f50704bbb630cbe38298d544a1f890f099a4696b1d6beba4'
+    'd5270c65a773bc76b76e814d35a2cb8077f7629a929800b1dfbe8303ddf7fc91'
+)
 
 prepare() {
   cd "SDL2-${pkgver}"
+  patch -p1 < "${srcdir}/11442.patch"
 }
 
 build() {


### PR DESCRIPTION
Touch controls are broken on Vita since SDL 2.30.7.
As this is quite a serious problem, update to the latest git version including the fix.

As the 2.30.7 version was never built in vitasdk, it's broken since about a month.
This patch fixes https://github.com/libsdl-org/SDL/issues/11441.
