### PR TITLE
ci: use actions/setup-python to install python 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,11 @@ jobs:
         merge-multiple: true
     - name: Install dependencies
       run: |
-        sudo add-apt-repository ppa:deadsnakes/ppa -y
         sudo apt-get update
-        sudo apt-get install fakeroot cmake cmake-data texinfo libtool-bin libarchive-tools pkg-config libc6-dev-i386 python2.7 python3.11
+        sudo apt-get install fakeroot cmake cmake-data texinfo libtool-bin libarchive-tools pkg-config libc6-dev-i386 python2.7
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Prepare Build
       run: |
         bash ./prepare.sh


### PR DESCRIPTION
Should reduce job errors related to ppa like:
```
Adding repository.
Adding deb entry to /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-jammy.list
Adding disabled deb-src entry to /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-jammy.list
Traceback (most recent call last):
  File "/usr/bin/add-apt-repository", line 364, in <module>
    sys.exit(0 if addaptrepo.main() else 1)
  File "/usr/bin/add-apt-repository", line 357, in main
    shortcut.add()
  File "/usr/lib/python3/dist-packages/softwareproperties/shortcuthandler.py", line 222, in add
    self.add_key()
  File "/usr/lib/python3/dist-packages/softwareproperties/shortcuthandler.py", line 398, in add_key
    if not all((self.trustedparts_file, self.trustedparts_content)):
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 141, in trustedparts_content
    key = self.lpppa.getSigningKeyData()
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/resource.py", line 592, in __call__
    response, content = self.root._browser._request(
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 429, in _request
    raise error
lazr.restfulclient.errors.ServerError: HTTP Error 504: Gateway Time-out
```