### PR TITLE
Revert "zstd: update package to version 1.5.7"

### DIFF
--- a/zstd/VITABUILD
+++ b/zstd/VITABUILD
@@ -1,26 +1,16 @@
 pkgname=libzstd
-pkgver=1.5.7
+pkgver=1.5.6
 pkgrel=1
 url='https://facebook.github.io/zstd/'
 source=("https://github.com/facebook/zstd/releases/download/v$pkgver/zstd-$pkgver.tar.gz")
-sha256sums=('eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3')
+sha256sums=('8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1')
 build() {
-  cd zstd-$pkgver
+  cd zstd-$pkgver/lib
 
-  mkdir _build && cd _build
-
-  cmake ../build/cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=$prefix \
-    -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake \
-    -DZSTD_BUILD_PROGRAMS=OFF \
-    -DZSTD_BUILD_STATIC=ON \
-    -DZSTD_BUILD_SHARED=OFF
-
-  make -j$(nproc)
+  make CC=arm-vita-eabi-gcc PREFIX=${prefix} libzstd.a libzstd.pc
 }
 
 package() {
-  cd zstd-$pkgver/_build
-  make DESTDIR=$pkgdir install
+  cd zstd-$pkgver/lib
+  make DESTDIR="$pkgdir" PREFIX=${prefix} install-pc install-static install-includes
 }


### PR DESCRIPTION
This reverts commit 4a42fcd237f13b78212a447429e6adea4592f371.
Reverting since the upstream CMakelists enables -fPIC which uses invalid relocation types for vitasdk.