### PR TITLE
Fix building on CMake 4.x

### DIFF
--- a/SceShaccCgExt/VITABUILD
+++ b/SceShaccCgExt/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=SceShaccCgExt
 pkgver=1.0.1
-pkgrel=1
+pkgrel=2
 url="https://github.com/bythos14/$pkgname"
 source=("https://github.com/bythos14/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('a1cda9f3d637032cc597f2f4fdbc17813e5c7c90943a7d44c2e35f013c8dbc0b')
@@ -9,7 +9,7 @@ depends=('taihen')
 build() {
   cd $pkgname-$pkgver
   mkdir build && cd build
-  cmake ..
+  cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc)
 }
 

--- a/bullet/VITABUILD
+++ b/bullet/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=bullet
 pkgver=2.87
-pkgrel=1
+pkgrel=2
 url="https://github.com/DrakonPL/bullet-physics-vita"
 source=("git+https://github.com/DrakonPL/bullet-physics-vita.git")
 sha256sums=('SKIP')
@@ -8,7 +8,7 @@ sha256sums=('SKIP')
 build() {
   cd bullet-physics-vita
   mkdir build && cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc)
 }
 

--- a/fftw/VITABUILD
+++ b/fftw/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=fftw
 pkgver=3.3.10
-pkgrel=2
+pkgrel=3
 url="https://www.fftw.org/"
 source=("https://www.fftw.org/fftw-${pkgver}.tar.gz")
 sha256sums=('56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467')
@@ -8,7 +8,7 @@ sha256sums=('56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467')
 build() {
   cd fftw-$pkgver
   mkdir build && cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF -DDISABLE_FORTRAN=ON
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF -DDISABLE_FORTRAN=ON
   make -j$(nproc)
 }
 

--- a/kubridge/VITABUILD
+++ b/kubridge/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=kubridge
 pkgver=9999
-pkgrel=2
+pkgrel=3
 url="https://github.com/bythos14/kubridge"
 source=("git+https://github.com/bythos14/kubridge.git#commit=a4ef20fc3ab07b493f9d7d67703272831e445e21")
 sha256sums=('SKIP')
@@ -9,7 +9,7 @@ depends=('taihen')
 build() {
   cd $pkgname
   mkdir build && cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc)
 }
 

--- a/libdebugnet/VITABUILD
+++ b/libdebugnet/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=libdebugnet
 pkgver=9999
-pkgrel=1
+pkgrel=2
 url="https://github.com/psxdev/debugnet"
 source=("git+https://github.com/psxdev/debugnet.git")
 sha256sums=('SKIP')
@@ -8,7 +8,7 @@ sha256sums=('SKIP')
 build() {
   cd debugnet/libdebugnet
   mkdir build && cd build
-  cmake ..  -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  cmake ..  -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc)
 }
 

--- a/libk/VITABUILD
+++ b/libk/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=libk
 pkgver=9999
-pkgrel=2
+pkgrel=3
 url="https://github.com/DaveeFTW/libk"
 source=("git+https://github.com/DaveeFTW/libk.git#branch=dev")
 sha256sums=('SKIP')
@@ -8,7 +8,7 @@ sha256sums=('SKIP')
 build() {
   cd libk
   mkdir build && cd build
-  cmake ..  -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix
+  cmake ..  -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc)
 }
 

--- a/libmodplug/VITABUILD
+++ b/libmodplug/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=libmodplug
 pkgver=0.8.9.0
-pkgrel=1
+pkgrel=2
 url="https://github.com/Konstanty/libmodplug"
 source=("git+https://github.com/Konstanty/libmodplug.git" "modplug.patch")
 sha256sums=('SKIP'
@@ -14,7 +14,7 @@ prepare() {
 build() {
   cd ${pkgname}
   mkdir build && cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DHAVE_SINF=1
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DHAVE_SINF=1
   make -j$(nproc)
 }
 

--- a/libsamplerate/VITABUILD
+++ b/libsamplerate/VITABUILD
@@ -1,18 +1,18 @@
 pkgname=libsamplerate
 pkgver=0.2.2
-pkgrel=1
+pkgrel=2
 url="https://libsndfile.github.io/libsamplerate/"
-source=("https://github.com/libsndfile/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('16e881487f184250deb4fcb60432d7556ab12cb58caea71ef23960aec6c0405a')
+source=("git+https://github.com/libsndfile/${pkgname}.git#commit=2ccde9568cca73c7b32c97fefca2e418c16ae5e3")
+sha256sums=('SKIP')
 
 build() {
-  cd $pkgname-$pkgver
+  cd $pkgname
   mkdir build && cd build
   cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DLIBSAMPLERATE_EXAMPLES=Off -DBUILD_TESTING=Off
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver/build
+  cd $pkgname/build
   make DESTDIR=$pkgdir install
 }

--- a/libvorbis/VITABUILD
+++ b/libvorbis/VITABUILD
@@ -1,19 +1,19 @@
 pkgname=libvorbis
 pkgver=1.3.7
-pkgrel=2
+pkgrel=3
 url="https://xiph.org/vorbis/"
-source=("http://downloads.xiph.org/releases/vorbis/$pkgname-$pkgver.tar.gz")
-sha256sums=('0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab')
+source=("git+https://gitlab.xiph.org/xiph/vorbis.git#commit=2d79800b6751dddd4b8b4ad50832faa5ae2a00d9")
+sha256sums=('SKIP')
 depends=('libogg')
 
 build() {
-  cd $pkgname-$pkgver
+  cd vorbis
   mkdir build && cd build
   cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver/build
+  cd vorbis/build
   make DESTDIR=$pkgdir install
 }

--- a/mini18n/VITABUILD
+++ b/mini18n/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=mini18n
 pkgver=0.2.1
-pkgrel=1
+pkgrel=2
 gitrev=1850682c1e56e93d04b0f352946c01dab475f88a
 url="https://github.com/bucanero/mini18n/"
 source=("git+https://github.com/bucanero/${pkgname}#commit=${gitrev}")
@@ -12,7 +12,7 @@ prepare() {
 
 build() {
   cd ${pkgname}/build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release
+  cmake .. -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc) mini18n-static
 }
 

--- a/polarssl/VITABUILD
+++ b/polarssl/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=polarssl
 pkgver=1.3.9
-pkgrel=1
+pkgrel=2
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
 source=("https://src.fedoraproject.org/repo/pkgs/polarssl/polarssl-1.3.9-gpl.tgz/48af7d1f0d5de512cbd6dacf5407884c/$pkgname-$pkgver-gpl.tgz")
 sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
@@ -8,7 +8,7 @@ sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
 build() {
   cd $pkgname-$pkgver
   sed '84s/.*/defined(__arm__)/' library/net.c > library/net.c
-  cmake . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE
+  cmake . -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   make -j$(nproc) polarssl
 }
 

--- a/sdl2_mixer_ext/VITABUILD
+++ b/sdl2_mixer_ext/VITABUILD
@@ -1,9 +1,9 @@
 pkgname=sdl2_mixer_ext
-pkgver=d149f1ecb1052ee207ca413e36b01923870faf17
-pkgrel=1
+pkgver=ca7875c85515adf8d9ff5d11703479ec34b907bb
+pkgrel=2
 url="https://github.com/WohlSoft/SDL-Mixer-X"
 source=("https://github.com/WohlSoft/SDL-Mixer-X/archive/${pkgver}.zip")
-sha256sums=("a4005a2e45838dd1d0f1205b7cb1e9c58b555b835bb5f651cfd4ab46de079b32")
+sha256sums=("2910c90dace002fc00872f262d9182c3d7e7bd80a823f138568fac64d3d2bca3")
 
 depends=('sdl2' 'libvorbis' 'libxmp' 'libmodplug' 'mpg123' 'flac' 'opusfile')
 

--- a/websocketpp/VITABUILD
+++ b/websocketpp/VITABUILD
@@ -1,19 +1,19 @@
 pkgname=websocketpp
 pkgver=0.8.2
-pkgrel=1
+pkgrel=2
 url="https://www.zaphoyd.com/projects/websocketpp/"
-source=("https://github.com/zaphoyd/websocketpp/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755')
+source=("git+https://github.com/zaphoyd/websocketpp.git#commit=4dfe1be74e684acca19ac1cf96cce0df9eac2a2d")
+sha256sums=('SKIP')
 depends=('boost')
 
 build() {
-  cd $pkgname-$pkgver
+  cd $pkgname
   mkdir build && cd build
   cmake .. -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake
   make -j$(nproc)
 }
 
 package () {
-  cd $pkgname-$pkgver/build
+  cd $pkgname/build
   make DESTDIR=$pkgdir install
 }


### PR DESCRIPTION
CMake 4.x ~~does not support~~ refuses to build projects which declare their target CMake version as <3.5. Fix the issue by either updating the affected packages, or adding a CMake directive to force-run it.