### PR TITLE
vitagl: remove compilation flags override

### DIFF
--- a/vitaGL/VITABUILD
+++ b/vitaGL/VITABUILD
@@ -8,7 +8,7 @@ depends=('libmathneon vitaShaRK taihen SceShaccCgExt')
 
 build() {
   cd $pkgname
-  make HAVE_SBRK=1 NO_DEBUG=1 CFLAGS="-std=gnu11 -Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=incompatible-pointer-types" CXXFLAGS="-std=gnu++11 -Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=incompatible-pointer-types" -j$(nproc)
+  make NO_DEBUG=1 -j$(nproc)
 }
 
 package () {


### PR DESCRIPTION
Fix build
-  `-mfp16-format=ieee` is a new compilation flags added in commit https://github.com/Rinnegatamante/vitaGL/commit/e07d7cff0b63e0248bc7ae4e86f8f0dc180cc3ed
- `HAVE_SBRK` was removed in commit https://github.com/Rinnegatamante/vitaGL/commit/8a5f8bc55190c6366de4ea865432c2fa16b79baa
- Do not override `CFLAGS`, use current `CFLAGS` from https://github.com/Rinnegatamante/vitaGL/blob/master/Makefile#L15