### PR TITLE
libimagequant: 4.4.1

### DIFF
--- a/libimagequant/VITABUILD
+++ b/libimagequant/VITABUILD
@@ -1,8 +1,8 @@
 pkgname=libimagequant
-pkgver=2.17.0
+pkgver=4.4.1
 pkgrel=1
 url="https://github.com/ImageOptim/libimagequant"
-source=("git+https://github.com/ImageOptim/libimagequant.git#tag=2.17.0")
+source=("git+https://github.com/ImageOptim/libimagequant.git#tag=4.4.1")
 sha256sums=('SKIP')
 
 prepare() {


### PR DESCRIPTION
Opened by vitasdk-autobuild. The version rises, which is
what makes pacman offer the rebuild; without that the file is
republished under the same name and nobody receives it.

A build of this recipe is reported back as a commit status.