### PR TITLE
Pin the vdpm the package builder installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz \
 # Clone and install VitaSDK using exact core snapshot or development bootstrap
 ARG VITASDK_CACHE_BUST
 ARG CORE_SNAPSHOT
-ARG VDPM_REF=master
+ARG VDPM_REF=v0.1.3
 RUN echo "VitaSDK Cache Bust: $VITASDK_CACHE_BUST" && \
     if [ -n "$CORE_SNAPSHOT" ]; then \
         echo "Installing VitaSDK from exact core snapshot: $CORE_SNAPSHOT" && \


### PR DESCRIPTION
The image that builds the package catalogue cloned vdpm from `master`, so it installed whichever commit that branch happened to be at when the image was built. Two builds of the same `packages` commit could end up with different clients, and nothing recorded which one went in.

A release tag fixes that, and `v0.1.3` is the one to use: installers from the releases before it seed from a bundle whose layout they no longer accept, so they fail outright on Linux and macOS.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).