### PR TITLE
libintl, libunistring: download from a mirror that answers

### DIFF
--- a/libintl/VITABUILD
+++ b/libintl/VITABUILD
@@ -2,7 +2,7 @@ pkgname=libintl
 pkgver=0.22.5
 pkgrel=1
 url="https://www.gnu.org/software/gettext/"
-source=("https://ftp.gnu.org/pub/gnu/gettext/gettext-${pkgver}.tar.gz")
+source=("https://mirrors.kernel.org/gnu/gettext/gettext-${pkgver}.tar.gz")
 sha256sums=('ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0')
 
 build() {

--- a/libunistring/VITABUILD
+++ b/libunistring/VITABUILD
@@ -2,7 +2,7 @@ pkgname=libunistring
 pkgver=1.2
 pkgrel=1
 url="https://www.gnu.org/software/libunistring/"
-source=("https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz")
+source=("https://mirrors.kernel.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz")
 sha256sums=('fd6d5662fa706487c48349a758b57bc149ce94ec6c30624ec9fdc473ceabbc8e')
 
 build() {


### PR DESCRIPTION
`ftp.gnu.org` has been timing out all week. These two are the only recipes in the catalogue that fetch from it — `freetype` already goes through the Savannah mirror.

Neither has ever built, so the last catalogue run published two packages short of what the recipes declare:

```
[vita] short of the recipes by 2
libintl
libunistring
ERROR: the catalogue published without 2 package(s) the recipes declare
```

Same bytes on the new host — I downloaded both and the declared sums verify unchanged:

| | declared | mirrors.kernel.org |
|---|---|---|
| gettext-0.22.5.tar.gz | `ec1705b1…96a0` | `ec1705b1…96a0` |
| libunistring-1.2.tar.gz | `fd6d5662…bc8e` | `fd6d5662…bc8e` |

pacman's `source=()` is a list of distinct files, not of mirrors, so there is no fallback to add — the URL has to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)